### PR TITLE
Serialization of multiple data attributes

### DIFF
--- a/jquery.nestable.js
+++ b/jquery.nestable.js
@@ -118,7 +118,7 @@
                     items.each(function()
                     {
                         var li   = $(this),
-                            item = { id: li.attr(list.options.itemIdAttribute) },
+                            item = li.data(),
                             sub  = li.children(list.options.listNodeName);
                         if (sub.length) {
                             item.children = step(sub);


### PR DESCRIPTION
By changing:

```
item = { id: li.attr(list.options.itemIdAttribute) },
```

To:

```
item = li.data(),
```

All data attributes will be serialized, i think this is useful, as it allows the user to specify extra attribues and pass custom data to the serialized string
