### PR TITLE
Fix change event triggered twice.

### DIFF
--- a/jquery.nestable.js
+++ b/jquery.nestable.js
@@ -452,8 +452,8 @@
                 }
                 // parent root list has changed
                 if (isNewRoot) {
-                    this.hasNewRoot = true;
                     this.dragRootEl = pointElRoot;
+                    this.hasNewRoot = this.el[0] !== this.dragRootEl[0];
                 }
             }
         }


### PR DESCRIPTION
According to:

``` js
if (this.hasNewRoot) {
    this.dragRootEl.trigger('change');
}
```

the change event is triggered on the new root on `dragStop`. However when you drag the item back inside its original root, this leads to trigger the change event twice on the original root.

This PR set `this.hasNewRoot` to `true` only if when the new root is different from the original root from which the drag start.
