### PR TITLE
allow non-draggable elements inside draggable elements of the same itemNodeName

### DIFF
--- a/jquery.nestable.js
+++ b/jquery.nestable.js
@@ -248,7 +248,7 @@
         {
             var mouse    = this.mouse,
                 target   = $(e.target),
-                dragItem = target.closest(this.options.itemNodeName);
+                dragItem = target.closest('.' + this.options.handleClass).closest(this.options.itemNodeName);
 
             this.placeEl.css('height', dragItem.height());
 


### PR DESCRIPTION
In my case, there can be deeply _nested content lists_ inside _handle divs_ of _draggable list items_ ...and I don't want them to be draggable. All that I want and expect to be draggable is defined via _handleClass_.
