### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ These advanced config options are also available:
 * `listClass` The class of all list elements (default `'dd-list'`)
 * `itemClass` The class of all list item elements (default `'dd-item'`)
 * `dragClass` The class applied to the list element that is being dragged (default `'dd-dragel'`)
+* `noDragClass` The class applied to an element to prevent dragging (default `'dd-nodrag'`)
 * `handleClass` The class of the content element inside each list item (default `'dd-handle'`)
 * `collapsedClass` The class applied to lists that have been collapsed (default `'dd-collapsed'`)
 * `placeClass` The class of the placeholder element (default `'dd-placeholder'`)


### PR DESCRIPTION
tried to include a button as part of a list element but it was triggering a drag event when clicked. fished around in the source code and saw you had a noDragClass to prevent. I didn't find it in your documentation so I added it. Great job on the plugin!
