### PR TITLE
Add support for click event

### DIFF
--- a/jquery.nestable.js
+++ b/jquery.nestable.js
@@ -189,6 +189,7 @@
             this.dragEl     = null;
             this.dragRootEl = null;
             this.dragDepth  = 0;
+            this.dragItem   = null;
             this.hasNewRoot = false;
             this.pointEl    = null;
         },
@@ -250,6 +251,8 @@
                 target   = $(e.target),
                 dragItem = target.closest(this.options.itemNodeName);
 
+            this.dragItem = dragItem;
+            
             this.placeEl.css('height', dragItem.height());
 
             mouse.offsetX = e.offsetX !== undefined ? e.offsetX : e.pageX - target.offset().left;
@@ -291,6 +294,10 @@
             var el = this.dragEl.children(this.options.itemNodeName).first();
             el[0].parentNode.removeChild(el[0]);
             this.placeEl.replaceWith(el);
+            
+            if (!this.moving) {
+                $(this.dragItem).trigger('click');
+            }
 
             this.dragEl.remove();
             this.el.trigger('change');
@@ -330,9 +337,9 @@
             var newAx   = Math.abs(mouse.distX) > Math.abs(mouse.distY) ? 1 : 0;
 
             // do nothing on first move
-            if (!mouse.moving) {
+            if (!this.moving) {
                 mouse.dirAx  = newAx;
-                mouse.moving = true;
+                this.moving = true;
                 return;
             }
 


### PR DESCRIPTION
Hi

This PR adds several things:
1. It stores the dragItem so that it can be retrieves everywhere. It may be possible to retrieve it from dragEl or pointEl but I didn't manage to do so…
2. It now correctly the moving attribute (https://github.com/dbushell/Nestable/blob/master/jquery.nestable.js#L188) - previously it was never updated and always to false.
3. Allow to listen to the "click" event. It assumes that if mouse has not moved on dragStop, then it is assumed to be a click, otherwise it is a drag&drop.
