### PR TITLE
Corrected bug on drag over multiple lists

### DIFF
--- a/jquery.nestable.js
+++ b/jquery.nestable.js
@@ -451,8 +451,9 @@
                     this.dragRootEl.append('<div class="' + opt.emptyClass + '"/>');
                 }
                 // parent root list has changed
+                this.dragRootEl = pointElRoot; // By Mario
                 if (isNewRoot) {
-                    this.dragRootEl = pointElRoot;
+                    // this.dragRootEl = pointElRoot; // By Mario
                     this.hasNewRoot = this.el[0] !== this.dragRootEl[0];
                 }
             }


### PR DESCRIPTION
When using multiple files, dragRootEl does not update their value, and wrong object is deleted.
With this change it works well.
