### PR TITLE
Events on expand/collapse

### DIFF
--- a/jquery.nestable.js
+++ b/jquery.nestable.js
@@ -199,6 +199,8 @@
             li.children('[data-action="expand"]').hide();
             li.children('[data-action="collapse"]').show();
             li.children(this.options.listNodeName).show();
+            this.el.trigger('expand', [li]);
+            li.trigger('expand');
         },
 
         collapseItem: function(li)
@@ -210,6 +212,8 @@
                 li.children('[data-action="expand"]').show();
                 li.children(this.options.listNodeName).hide();
             }
+            this.el.trigger('collapse', [li]);
+            li.trigger('collapse');
         },
 
         expandAll: function()


### PR DESCRIPTION
Added events to trigger on expand and on collapse.
Then events are triggered for the list as well for each list item. The client choose which to listen to.

``` javascript
$('#nestedlist').on('expand', function(e, li){
    var id=$(li).data('id');
});

$('#nestedlist').on('expand', '[data-id=5]', function(e){
    var id=$(this).data('id'); //id=5
});
```
