### PR TITLE
Added Support for Max Items in List

### DIFF
--- a/jquery.nestable.js
+++ b/jquery.nestable.js
@@ -47,7 +47,8 @@
             collapseBtnHTML : '<button data-action="collapse" type="button">Collapse</button>',
             group           : 0,
             maxDepth        : 5,
-            threshold       : 20
+            threshold       : 20,
+            maxItems		: null
         };
 
     function Plugin(element, options)
@@ -67,6 +68,7 @@
             list.reset();
 
             list.el.data('nestable-group', this.options.group);
+            list.el.data('nestable-max-items', this.options.maxItems);
 
             list.placeEl = $('<div class="' + list.options.placeClass + '"/>');
 
@@ -416,6 +418,13 @@
             // find parent list of item under cursor
             var pointElRoot = this.pointEl.closest('.' + opt.rootClass),
                 isNewRoot   = this.dragRootEl.data('nestable-id') !== pointElRoot.data('nestable-id');
+
+            // check item limit for destination (drop list)
+            itemsInDropList = pointElRoot.find(opt.itemNodeName).length;
+            maxItemsInDropList = pointElRoot.data('nestable-max-items');
+            if(maxItemsInDropList != null && itemsInDropList >= maxItemsInDropList){
+            	return;
+            }
 
             /**
              * move vertical


### PR DESCRIPTION
Support option for allowing a user to limit the number of items in a nestable list. This concerns itself only with the destination (drop list) item count. The comparison for >= is in the case that more than the item limit was rendered to the list (i.e. even though you limited nestable to 3 items, the server side template rendered 5 items). I realize this could be more concise and have better performance, but is presented for readability.
