### PR TITLE
Added `disableNest` option (default to `false`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ These advanced config options are also available:
 * `emptyClass` The class used for empty list placeholder elements (default `'dd-empty'`)
 * `expandBtnHTML` The HTML text used to generate a list item expand button (default `'<button data-action="expand">Expand></button>'`)
 * `collapseBtnHTML` The HTML text used to generate a list item collapse button (default `'<button data-action="collapse">Collapse</button>'`)
+* `disableNest` Prevent drag an element to children or parent elements. That is to say you can only drag an element vertically. ( default `false` )
 
 **Inspect the [Nestable Demo](http://dbushell.github.com/Nestable/) for guidance.**
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ These advanced config options are also available:
 
 ## Change Log
 
+### 7th July 2014
+
+* Added `disableNest` option (default to `false`)
+
 ### 15th October 2012
 
 * Merge for Zepto.js support

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ These advanced config options are also available:
 * `emptyClass` The class used for empty list placeholder elements (default `'dd-empty'`)
 * `expandBtnHTML` The HTML text used to generate a list item expand button (default `'<button data-action="expand">Expand></button>'`)
 * `collapseBtnHTML` The HTML text used to generate a list item collapse button (default `'<button data-action="collapse">Collapse</button>'`)
-* `disableNest` Prevent drag an element to children or parent elements. That is to say you can only drag an element vertically. ( default `false` )
+* `disableNest` Prevent dragging an element to children or parent elements. That is to say you can only drag an element vertically. ( default `false` )
 
 **Inspect the [Nestable Demo](http://dbushell.github.com/Nestable/) for guidance.**
 

--- a/jquery.nestable.js
+++ b/jquery.nestable.js
@@ -47,7 +47,8 @@
             collapseBtnHTML : '<button data-action="collapse" type="button">Collapse</button>',
             group           : 0,
             maxDepth        : 5,
-            threshold       : 20
+            threshold       : 20,
+            disableNest     : false
         };
 
     function Plugin(element, options)
@@ -269,10 +270,12 @@
             dragItem.appendTo(this.dragEl);
 
             $(document.body).append(this.dragEl);
+
             this.dragEl.css({
                 'left' : e.pageX - mouse.offsetX,
                 'top'  : e.pageY - mouse.offsetY
             });
+
             // total depth of dragging item
             var i, depth,
                 items = this.dragEl.find(this.options.itemNodeName);
@@ -306,10 +309,16 @@
                 opt   = this.options,
                 mouse = this.mouse;
 
-            this.dragEl.css({
-                'left' : e.pageX - mouse.offsetX,
-                'top'  : e.pageY - mouse.offsetY
-            });
+            if (opt.disableNest) {
+                this.dragEl.css({
+                    'top'  : e.pageY - mouse.offsetY
+                });
+            } else {
+                this.dragEl.css({
+                    'left' : e.pageX - mouse.offsetX,
+                    'top'  : e.pageY - mouse.offsetY
+                });
+            }
 
             // mouse position last events
             mouse.lastX = mouse.nowX;


### PR DESCRIPTION
In some cases, I have to disable nesting. So I added an option for this great plugin.

`disableNest` 
Prevent dragging an element to children or parent elements. That is to say you can only drag an element vertically. ( default `false` )
