### PR TITLE
added checking for stopped propagation for mousedown event

### DIFF
--- a/jquery.nestable.js
+++ b/jquery.nestable.js
@@ -86,6 +86,9 @@
 
             var onStartEvent = function(e)
             {
+                if (e.isPropagationStopped()) {
+                    return
+                }
                 var handle = $(e.target);
                 if (!handle.hasClass(list.options.handleClass)) {
                     if (handle.closest('.' + list.options.noDragClass).length) {


### PR DESCRIPTION
Usecase

```
$('.dd').on('mousedown', function (e) {
    if (isShouldBeClicked(e)) {
        e.stopPropagation();
        onClicked();
    }
}).nestable().on('change', function () {
    // logic goes here
});
```
