### PR TITLE
Add option to determine if the list should start expanded or collapsed

### DIFF
--- a/jquery.nestable.js
+++ b/jquery.nestable.js
@@ -42,7 +42,8 @@
             collapseBtnHTML : '<button data-action="collapse" type="button">Collapse</button>',
             group           : 0,
             maxDepth        : 5,
-            threshold       : 20
+            threshold       : 20,
+            expanded        : true
         };
 
     function Plugin(element, options)
@@ -237,7 +238,13 @@
                 li.prepend($(this.options.expandBtnHTML));
                 li.prepend($(this.options.collapseBtnHTML));
             }
-            li.children('[data-action="expand"]').hide();
+
+            if (this.options.expanded) {
+                li.children('[data-action="expand"]').hide();
+            }
+            else {
+                li.addClass(this.options.collapsedClass).children('[data-action="collapse"]').hide();
+            }
         },
 
         unsetParent: function(li)


### PR DESCRIPTION
This option will help a user if s/he wants the nested list to start in a collapsed state. After poking around a bit for a simple way to do this, I found no existing option to do that, so I wrote this simple hack to facilitate it.
