### PR TITLE
Adds @ohaag's onDrop callback + prevent placement based on (boolean) return value

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ Then activate with jQuery like so:
 
     $('.dd').nestable({ /* config options */ });
 
+### Callbacks
+
+The `onDrop` callback function is called when the dragged element is dropped.
+The dropped element is passed in parameter in his current state.
+
 ### Events
 
 The `change` event is fired when items are reordered.
@@ -82,6 +87,7 @@ These advanced config options are also available:
 * `emptyClass` The class used for empty list placeholder elements (default `'dd-empty'`)
 * `expandBtnHTML` The HTML text used to generate a list item expand button (default `'<button data-action="expand">Expand></button>'`)
 * `collapseBtnHTML` The HTML text used to generate a list item collapse button (default `'<button data-action="collapse">Collapse</button>'`)
+* `onDrop` callback function used when the dragged element is dropped (default `function (item) {}`)
 
 **Inspect the [Nestable Demo](http://dbushell.github.com/Nestable/) for guidance.**
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,25 @@ Then activate with jQuery like so:
 The `onDrop` callback function is called when the dragged element is dropped.
 The dropped element is passed in parameter in his current state.
 
+When `true` is returned in this callback, dropping at the current location is allowed.
+When `false` is returned, the item is returned to it's original pick-up position.
+This allows custom logic that can 'deny' a dropping. For example:
+
+    $('.dd').nestable({
+        onDrop: function (item) {
+            var existingBrand = false;
+            item.siblings().each(function () {
+                if ($(this).data("brand") == item.data("brand")) {
+                    existingBrand = true;
+                    alert('"' + item.data("brand") + '" is already in this sublist!');
+                }
+            });
+            return !existingBrand;
+        }
+    });
+
+Please note that the `change` event is only fired when a dropping is allowed (return `true`).
+
 ### Events
 
 The `change` event is fired when items are reordered.
@@ -85,13 +104,22 @@ These advanced config options are also available:
 * `collapsedClass` The class applied to lists that have been collapsed (default `'dd-collapsed'`)
 * `placeClass` The class of the placeholder element (default `'dd-placeholder'`)
 * `emptyClass` The class used for empty list placeholder elements (default `'dd-empty'`)
+* `origPosClass` The class used for the item's original position placeholder (default `'dd-origpos'`)
 * `expandBtnHTML` The HTML text used to generate a list item expand button (default `'<button data-action="expand">Expand></button>'`)
 * `collapseBtnHTML` The HTML text used to generate a list item collapse button (default `'<button data-action="collapse">Collapse</button>'`)
-* `onDrop` callback function used when the dragged element is dropped (default `function (item) {}`)
+* `onDrop` callback function used when the dragged element is dropped (default `function (item) { return true; }`).
 
 **Inspect the [Nestable Demo](http://dbushell.github.com/Nestable/) for guidance.**
 
 ## Change Log
+
+### 1st June 2015
+
+* Added allowing/denying of dropping an item at it's current position by using the (previously implemented) `onDrop` callback.
+
+### 3rd December 2014
+
+* Added `onDrop` callback function which is called when the dragged element is dropped.
 
 ### 15th October 2012
 

--- a/index.html
+++ b/index.html
@@ -245,6 +245,41 @@ p { line-height: 1.5em; }
                 </li>
             </ol>
         </div>
+    </div>
+
+    <div class="cf nestable-lists">
+
+        <p><strong>`onDrop` Callback (+ denying items to be dropped)</strong></p>
+
+        <p>
+            With the new onDrop callback, you can implement custom logic for when an item is dropped.
+            You can also deny items by returning false, which will make it return to it's original position.
+        </p>
+
+        <div class="dd" id="nestable4">
+            <ol class="dd-list">
+                <li data-brand="Mercedes" class="dd-item dd3-item" data-id="13">
+                    <div class="dd-handle dd3-handle">Drag</div><div class="dd3-content">Mercedes</div>
+                </li>
+                <li data-brand="BMW" class="dd-item dd3-item" data-id="14">
+                    <div class="dd-handle dd3-handle">Drag</div><div class="dd3-content">BMW</div>
+                </li>
+                <li data-brand="Audi" class="dd-item dd3-item" data-id="15">
+                    <div class="dd-handle dd3-handle">Drag</div><div class="dd3-content">Audi</div>
+                    <ol class="dd-list">
+                        <li data-brand="Tesla" class="dd-item dd3-item" data-id="16">
+                            <div class="dd-handle dd3-handle">Drag</div><div class="dd3-content">Tesla</div>
+                        </li>
+                        <li data-brand="BMW" class="dd-item dd3-item" data-id="17">
+                            <div class="dd-handle dd3-handle">Drag</div><div class="dd3-content">BMW</div>
+                        </li>
+                        <li data-brand="Toyota" class="dd-item dd3-item" data-id="18">
+                            <div class="dd-handle dd3-handle">Drag</div><div class="dd3-content">Toyota</div>
+                        </li>
+                    </ol>
+                </li>
+            </ol>
+        </div>
 
     </div>
 
@@ -297,6 +332,20 @@ $(document).ready(function()
     });
 
     $('#nestable3').nestable();
+
+    // `onDrop` Callback (+ denying items to be dropped)
+    $('#nestable4').nestable({
+        onDrop: function (item) {
+            var existingBrand = false;
+            item.siblings().each(function () {
+                if ($(this).data("brand") == item.data("brand")) {
+                    existingBrand = true;
+                    alert('"' + item.data("brand") + '" is already in this sublist!');
+                }
+            });
+            return !existingBrand;
+        }
+    });
 
 });
 </script>

--- a/jquery.nestable.js
+++ b/jquery.nestable.js
@@ -256,7 +256,7 @@
                 target   = $(e.target),
                 dragItem = target.closest(this.options.itemNodeName);
 
-            this.origPos = dragItem.after("<div class='" + this.options.origPosClass + "'></div>").next();
+            this.origPos = dragItem.after("<li class='" + this.options.origPosClass + "'></li>").next();
             this.placeEl.css('height', dragItem.height());
 
             mouse.offsetX = e.offsetX !== undefined ? e.offsetX : e.pageX - target.offset().left;
@@ -297,7 +297,11 @@
             this.dragEl.remove();
 
             if (!!this.options.onDrop(el)) {
+                parent = this.origPos.parent();
                 this.origPos.remove();
+                if (!parent.children().length) {
+                    this.unsetParent(parent.parent());
+                }
 
                 this.el.trigger('change');
                 if (this.hasNewRoot) {
@@ -371,7 +375,7 @@
                 mouse.distAxX = 0;
                 prev = this.placeEl.prev(opt.itemNodeName);
                 // increase horizontal level if previous sibling exists and is not collapsed
-                if (mouse.distX > 0 && prev.length && !prev.hasClass(opt.collapsedClass)) {
+                if (mouse.distX > 0 && prev.length && !prev.hasClass(opt.collapsedClass) && !prev.hasClass(opt.origPosClass)) {
                     // cannot increase level when item above is collapsed
                     list = prev.find(opt.listNodeName).last();
                     // check if depth limit has reached

--- a/jquery.nestable.js
+++ b/jquery.nestable.js
@@ -42,7 +42,8 @@
             collapseBtnHTML : '<button data-action="collapse" type="button">Collapse</button>',
             group           : 0,
             maxDepth        : 5,
-            threshold       : 20
+            threshold       : 20,
+            onDrop          : function (item) {}
         };
 
     function Plugin(element, options)
@@ -297,6 +298,8 @@
                 this.dragRootEl.trigger('change');
             }
             this.reset();
+            
+            this.options.onDrop(el);
         },
 
         dragMove: function(e)

--- a/jquery.nestable.js
+++ b/jquery.nestable.js
@@ -38,12 +38,13 @@
             placeClass      : 'dd-placeholder',
             noDragClass     : 'dd-nodrag',
             emptyClass      : 'dd-empty',
+            origPosClass    : 'dd-origpos',
             expandBtnHTML   : '<button data-action="expand" type="button">Expand</button>',
             collapseBtnHTML : '<button data-action="collapse" type="button">Collapse</button>',
             group           : 0,
             maxDepth        : 5,
             threshold       : 20,
-            onDrop          : function (item) {}
+            onDrop          : function (item) { return true; }
         };
 
     function Plugin(element, options)
@@ -193,6 +194,7 @@
             this.dragEl     = null;
             this.dragRootEl = null;
             this.dragDepth  = 0;
+            this.origPos    = null;
             this.hasNewRoot = false;
             this.pointEl    = null;
         },
@@ -254,6 +256,7 @@
                 target   = $(e.target),
                 dragItem = target.closest(this.options.itemNodeName);
 
+            this.origPos = dragItem.after("<div class='" + this.options.origPosClass + "'></div>").next();
             this.placeEl.css('height', dragItem.height());
 
             mouse.offsetX = e.offsetX !== undefined ? e.offsetX : e.pageX - target.offset().left;
@@ -291,15 +294,21 @@
             var el = this.dragEl.children(this.options.itemNodeName).first();
             el[0].parentNode.removeChild(el[0]);
             this.placeEl.replaceWith(el);
-
             this.dragEl.remove();
-            this.el.trigger('change');
-            if (this.hasNewRoot) {
-                this.dragRootEl.trigger('change');
+
+            if (!!this.options.onDrop(el)) {
+                this.origPos.remove();
+
+                this.el.trigger('change');
+                if (this.hasNewRoot) {
+                    this.dragRootEl.trigger('change');
+                }
+            } else {
+                this.origPos.replaceWith(el.clone());
+                el.remove();
             }
+
             this.reset();
-            
-            this.options.onDrop(el);
         },
 
         dragMove: function(e)


### PR DESCRIPTION
Forked ohaag's onDrop callback functionality.

Added new functionality: When dragging and dropping an item, you can use the onDrop-callback's return value to indicate whether an item is allowed to be placed at the 'dropped' position.
If it is, you can return true to allow this, and if it isn't, you can return false to revert the dragged item to it's original position.

All documentation and examples have been updated to reflect these (two) changes.
