### PR TITLE
optional name for change event

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,14 @@ These advanced config options are also available:
 * `emptyClass` The class used for empty list placeholder elements (default `'dd-empty'`)
 * `expandBtnHTML` The HTML text used to generate a list item expand button (default `'<button data-action="expand">Expand></button>'`)
 * `collapseBtnHTML` The HTML text used to generate a list item collapse button (default `'<button data-action="collapse">Collapse</button>'`)
+* `changeEvent` The name of the event that is triggered upon change in the tree (default `'change'`)
 
 **Inspect the [Nestable Demo](http://dbushell.github.com/Nestable/) for guidance.**
 
 ## Change Log
+
+### 16th January 2017
+* Added the `changeEvent` option ([Gabriel Zerbib](https://github.com/zzgab)
 
 ### 15th October 2012
 

--- a/index.html
+++ b/index.html
@@ -137,6 +137,12 @@ p { line-height: 1.5em; }
 .dd3-handle:before { content: '≡'; display: block; position: absolute; left: 0; top: 3px; width: 100%; text-align: center; text-indent: 0; color: #fff; font-size: 20px; font-weight: normal; }
 .dd3-handle:hover { background: #ddd; }
 
+/**
+ * Socialite
+ */
+
+.socialite { display: block; float: left; height: 35px; }
+
     </style>
 </head>
 <body>
@@ -145,7 +151,14 @@ p { line-height: 1.5em; }
 
     <p>Drag &amp; drop hierarchical list with mouse and touch compatibility (jQuery plugin)</p>
 
-    <p><strong><a href="https://github.com/dbushell/Nestable">Code on GitHub</a></strong></p>
+    <p><strong><a href="https://github.com/dbushell/Nestable">Download on GitHub</a></strong></p>
+
+    <div class="cf">
+    <a href="http://twitter.com/share" class="socialite twitter-share" data-via="dbushell" data-text="jQuery Nestable plugin" data-url="http://dbushell.github.com/Nestable/" data-size="large" rel="nofollow" target="_blank">
+        <span class="vhidden">Share on Twitter</span>
+    </a>
+    </div>
+
 
 <p><strong>PLEASE NOTE: I cannot provide any support or guidance beyond this README. If this code helps you that's great but I have no plans to develop Nestable beyond this demo (it's not a final product and has limited functionality). I cannot reply to any requests for help.</strong></p>
 
@@ -248,9 +261,9 @@ p { line-height: 1.5em; }
 
     </div>
 
-    <p class="small">Copyright &copy; <a href="http://dbushell.com/">David Bushell</a> | Made for <a href="http://www.browserlondon.com/">Browser</a></p>
+    <p class="small">Copyright &copy; <a href="https://dbushell.com/">David Bushell</a> | Made for <a href="http://www.browserlondon.com/">Browser</a></p>
 
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 <script src="jquery.nestable.js"></script>
 <script>
 

--- a/jquery.nestable.js
+++ b/jquery.nestable.js
@@ -42,7 +42,8 @@
             collapseBtnHTML : '<button data-action="collapse" type="button">Collapse</button>',
             group           : 0,
             maxDepth        : 5,
-            threshold       : 20
+            threshold       : 20,
+            changeEvent     : 'change'
         };
 
     function Plugin(element, options)
@@ -292,9 +293,9 @@
             this.placeEl.replaceWith(el);
 
             this.dragEl.remove();
-            this.el.trigger('change');
+            this.el.trigger(this.options.changeEvent);
             if (this.hasNewRoot) {
-                this.dragRootEl.trigger('change');
+                this.dragRootEl.trigger(this.options.changeEvent);
             }
             this.reset();
         },


### PR DESCRIPTION
This feature addresses Issue #35
The default behavior remains to trigger `'change'` but it can be configured to another event name, for disambiguation purposes with the native `'change'` event of HTML inputs which could be embedded inside the Nestable tree.