### PR TITLE
Improvement: Pass element that did move

### DIFF
--- a/jquery.nestable.js
+++ b/jquery.nestable.js
@@ -292,7 +292,7 @@
             this.placeEl.replaceWith(el);
 
             this.dragEl.remove();
-            this.el.trigger('change');
+            this.el.trigger('change', el);
             if (this.hasNewRoot) {
                 this.dragRootEl.trigger('change');
             }


### PR DESCRIPTION
We want to track what element did change as we don't have full tree rendered, this pass the moved element so we can get data from moved element attributes.

This change will simply pass the moved element with change event.