### PR TITLE
Add Cloneable Nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ You can change the follow options:
 
 * `maxDepth` number of levels an item can be nested (default `5`)
 * `group` group ID to allow dragging between lists (default `0`)
+* Class your itemNodeName with `clone` to clone the node on move (does not delete from original list)
 
 These advanced config options are also available:
 
@@ -86,6 +87,10 @@ These advanced config options are also available:
 **Inspect the [Nestable Demo](http://dbushell.github.com/Nestable/) for guidance.**
 
 ## Change Log
+
+### 24th September 2018
+
+* Add cloneable nodes
 
 ### 15th October 2012
 

--- a/jquery.nestable.js
+++ b/jquery.nestable.js
@@ -265,8 +265,19 @@
             this.dragEl = $(document.createElement(this.options.listNodeName)).addClass(this.options.listClass + ' ' + this.options.dragClass);
             this.dragEl.css('width', dragItem.width());
 
-            dragItem.after(this.placeEl);
-            dragItem[0].parentNode.removeChild(dragItem[0]);
+            if($(dragItem[0]).hasClass("clone"))
+            {
+                var cloneNode = dragItem[0].cloneNode(true);
+                dragItem[0].parentNode.replaceChild(cloneNode, dragItem[0]);
+                $(dragItem[0]).removeClass("clone");
+                dragItem.after(this.placeEl);
+            }
+            else
+            {
+                dragItem.after(this.placeEl);
+                dragItem[0].parentNode.removeChild(dragItem[0]);
+            }
+
             dragItem.appendTo(this.dragEl);
 
             $(document.body).append(this.dragEl);


### PR DESCRIPTION
Allows for nodes to be able to be cloned - instead of removing them from one list, after classing the node, it will stay in the original list and also move to the new one.